### PR TITLE
assign should take the first name given a vector

### DIFF
--- a/13_expressions/02_names/exercise2.r
+++ b/13_expressions/02_names/exercise2.r
@@ -14,7 +14,9 @@ get2("x", env = .GlobalEnv)
 
 ### Write an equivalent to assign() using as.name(), substitute(), and eval().
 assign2 <- function(x, value, env) {
-  env[[eval(x)]] <- eval(substitute(value))
+  eval(substitute(x <- value,list(x = as.name(x), value = value)), env)
+  if (length(x) > 1)
+    warning('only the first element is used as variable name')
 }
 ## somewhat convoluted?
 e <- new.env()


### PR DESCRIPTION
when given a vector as first input, as.name will take the first, so will default assign implementations
eg:

```
e <- new.env()
assign2(c('x','y'), 3, e)
Warning message:
    In assign2(c("x", "y"), 3, e) :
    only the first element is used as variable name
e$x
[1] 3
```
    
