### PR TITLE
Fix second versions of All() and Any()

### DIFF
--- a/09_functionals/04_manipulating_lists/exercise4.r
+++ b/09_functionals/04_manipulating_lists/exercise4.r
@@ -24,21 +24,29 @@ All(function(x) x > 1, iris$Petal.Length)    # Note that this is equivalent to `
 
 # Also, if using `any` in `Any` is seen as cheating, here's a more elegant alternative
 # (that I found elsewhere, not my own invention):
-Any <- function(f, x) {
-  Reduce(`&&`, x, TRUE)
+Any2 <- function(f, x) {
+  Reduce(`||`, vapply(x, f, logical(1)))
 }
+testthat::test_that("Any() works", {
+    testthat::expect_true(Any2(is.numeric, list(1, "a")))
+    testthat::expect_false(Any2(is.numeric, list("a", "b")))
+})
 
 # and All...
-All <- function(f, x) {
-  Reduce(`||`, x, TRUE)
+All2 <- function(f, x) {
+  Reduce(`&&`, vapply(x, f, logical(1)))
 }
+testthat::test_that("All2() works", {
+    testthat::expect_true(All2(is.numeric, list(1, 2)))
+    testthat::expect_false(All2(is.numeric, list(1, "a")))
+})
 
 # Another attempt:
 
-Any2 <- function(f, x) {
+Any3 <- function(f, x) {
   sum(vapply(x, f, logical(1)) >= 1)
 }
 
-All2 <- function(f, x) {
+All3 <- function(f, x) {
   sum(vapply(x, f, logical(1)) == length(x))
 }


### PR DESCRIPTION
Currently, the second versions of All() and Any() do not behave as
expected. This can be seen with, for example, the following:

```r
testthat::expect_true(Any(identity, list(TRUE, FALSE)))

testthat::expect_false(All(identity, list(TRUE, FALSE)))
```

There are two problems:

 1. The predicate function, f, is never actually applied to x (in other
    words, it doesn't matter at all what f is); and

 2. the logic is incorrect (All() will currently always return TRUE and
    Any() will currently return FALSE in some cases where it should
    return TRUE)

This commit fixes the second versions of All() and Any(), renames all
instances to have a number indicating the version, and adds some tests
for All2() and Any2() using the testthat package.